### PR TITLE
Fix voices search

### DIFF
--- a/lib/voicemaker/api.rb
+++ b/lib/voicemaker/api.rb
@@ -28,7 +28,7 @@ module Voicemaker
       if search
         voices.select do |voice|
           search_string = voice.values.join(' ').downcase
-          search.any? { |query| search_string.include? query.downcase }
+          search.all? { |query| search_string.include? query.downcase }
         end
       else
         voices

--- a/lib/voicemaker/api.rb
+++ b/lib/voicemaker/api.rb
@@ -20,9 +20,13 @@ module Voicemaker
     # Returns a list of voices, with optional search criteria (array)
     def voices(search = nil)
       search = nil if search&.empty?
+      search = [search] if search.is_a? String
       response = HTTP.auth(auth_header).get "#{base_uri}/list"
+
       raise BadResponse, "#{response.status}\n#{response.body}" unless response.status.success?
+      
       voices = response.parse.dig 'data', 'voices_list'
+      
       raise BadResponse, "Unexpected response: #{response}" unless voices
 
       if search

--- a/lib/voicemaker/command.rb
+++ b/lib/voicemaker/command.rb
@@ -20,7 +20,7 @@ module Voicemaker
     option "-l --language LANG", "Limit results to a specific language"
     option "-s --save PATH", "Save output to output YAML file"
 
-    param "SEARCH", "Provide one or more text strings to search for (case insensitive)"
+    param "SEARCH", "Provide one or more text strings to search for (case insensitive AND search)"
     param "CONFIG", "Path to config file"
     param "OUTPUT", "Path to output mp3/wav file. If not provided, the filename will be the same as the config file, with wav/mp3 extension"
     param "INDIR", "Path to input directory, containing config YAML files"

--- a/spec/approvals/api/voices-search-array
+++ b/spec/approvals/api/voices-search-array
@@ -1,0 +1,7 @@
+---
+- Engine: neural
+  VoiceId: ai2-John
+  VoiceGender: Male (Kid)
+  VoiceWebname: John
+  Country: US
+  Language: en-US

--- a/spec/approvals/cli/help
+++ b/spec/approvals/cli/help
@@ -39,7 +39,7 @@ Options:
 
 Parameters:
   SEARCH
-    Provide one or more text strings to search for (case insensitive)
+    Provide one or more text strings to search for (case insensitive AND search)
 
   CONFIG
     Path to config file

--- a/spec/approvals/cli/voices-search2
+++ b/spec/approvals/cli/voices-search2
@@ -1,11 +1,5 @@
 [32m---
 - Engine:[0m neural[32m
-  VoiceId:[0m ai2-John[32m
-  VoiceGender:[0m Male (Kid)[32m
-  VoiceWebname:[0m John[32m
-  Country:[0m US[32m
-  Language:[0m en-US[32m
-- Engine:[0m neural[32m
   VoiceId:[0m ai1-Amy[32m
   VoiceGender:[0m Female (Kid)[32m
   VoiceWebname:[0m Amy[32m

--- a/spec/voicemaker/api_spec.rb
+++ b/spec/voicemaker/api_spec.rb
@@ -19,9 +19,15 @@ describe API do
       expect(subject.voices.to_yaml).to match_approval('api/voices')
     end
 
+    context "with a search string argument" do
+      it "returns only the voices that include the word" do
+        expect(subject.voices('kid').to_yaml).to match_approval('api/voices-search')
+      end
+    end
+
     context "with a search array argument" do
-      it "returns only the voices that include at least one of the words" do
-        expect(subject.voices(['kid']).to_yaml).to match_approval('api/voices-search')
+      it "returns only the voices that include all of the words" do
+        expect(subject.voices(['kid', 'en-us']).to_yaml).to match_approval('api/voices-search-array')
       end
     end
   end

--- a/spec/voicemaker/command_spec.rb
+++ b/spec/voicemaker/command_spec.rb
@@ -30,8 +30,8 @@ describe Command do
     end
 
     context "with multiple search strings" do
-      it "only shows the voices matching any (or) string" do
-        expect { subject.run %w[voices kid gb] }.to output_approval 'cli/voices-search2'
+      it "only shows the voices matching all (AND) string" do
+        expect { subject.run %w[voices female ai1] }.to output_approval 'cli/voices-search2'
       end
     end
 


### PR DESCRIPTION
- Voice search was set to OR search, rather than the intended AND search
- Allow `API#voices` to handle string or array (`api.voices 'term'` instead of `api.voices ['term']`)
